### PR TITLE
feat!: validate S3 checksums on upload and export

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "devDependencies": {
+    "@types/crypto-js": "^4.2.2",
     "@types/node": "^20.1.0",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
@@ -40,6 +41,7 @@
   "dependencies": {
     "@scribelabsai/auth": "^1.3.0",
     "aws-sigv4-fetch": "^2.1.1",
+    "crypto-js": "4.2.0",
     "zod": "^3.22.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "devDependencies": {
-    "@types/crypto-js": "^4.2.2",
+    "@types/crypto-js": "3.1.47",
     "@types/node": "^20.1.0",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,4 @@
-import {
-  Auth,
-  Challenge,
-  Credentials,
-  RefreshToken,
-  Tokens,
-  UsernamePassword,
-} from '@scribelabsai/auth';
+import { Auth, Credentials, RefreshToken, UsernamePassword } from '@scribelabsai/auth';
 import { createSignedFetcher } from 'aws-sigv4-fetch';
 import Base64 from 'crypto-js/enc-base64';
 import Hex from 'crypto-js/enc-hex';
@@ -34,7 +27,7 @@ const ErrorSchema = object({
 export class ScribeMIClient {
   readonly env: Environment;
   readonly authClient: Auth;
-  tokens: Tokens | Challenge | undefined;
+  tokens: Awaited<ReturnType<Auth['getTokens']>> | undefined;
   userId: string | undefined;
   credentials: Credentials | undefined;
   fetch: typeof fetch | undefined;

--- a/tests/fetchModel.test.ts
+++ b/tests/fetchModel.test.ts
@@ -1,0 +1,69 @@
+import { config as configureEnv } from 'dotenv';
+import { describe, expect, it, vi } from 'vitest';
+import { EnvironmentSchema } from '../src/env-schema.js';
+import { ScribeMIClient } from '../src/index.js';
+import type { MIModel, MITask } from '../src/schema.js';
+
+configureEnv();
+
+const env = EnvironmentSchema.parse(process.env);
+
+const username = process.env['USERNAME'];
+const password = process.env['PASSWORD'];
+if (!username) {
+  throw new Error('Missing ENV.USERNAME');
+}
+if (!password) {
+  throw new Error('Missing ENV.PASSWORD');
+}
+
+const MOCK_MODEL: MIModel = {
+  company: 'EXAMPLE CO LTD',
+  dateReporting: '2024-01-01',
+  covering: 'year',
+  items: [],
+};
+const MOCK_URL_INVALID_CHECKSUM = 'mock-url-invalid-checksum';
+
+global.fetch = vi.fn(
+  async (url: URL | RequestInfo) =>
+    new Response(JSON.stringify(MOCK_MODEL), {
+      status: 200,
+      headers: {
+        ETag:
+          url === MOCK_URL_INVALID_CHECKSUM
+            ? '"invalid-checksum"'
+            : '"3f627dbbd74547377281ff090bf313eb"',
+      },
+    })
+);
+
+describe('fetchModel', () => {
+  const client = new ScribeMIClient(env);
+
+  it('succeeds if the checksum is valid', async () => {
+    const mockTask: MITask = {
+      client: 'Scribe',
+      jobid: 'abcdabcd',
+      status: 'SUCCESS',
+      submitted: 99995,
+      modelUrl: 'mock-url',
+    };
+
+    const model = await client.fetchModel(mockTask);
+
+    expect(model).toEqual(MOCK_MODEL);
+  });
+
+  it('fails if the checksum is invalid', async () => {
+    const mockTask: MITask = {
+      client: 'Scribe',
+      jobid: 'abcdabcd',
+      status: 'SUCCESS',
+      submitted: 99995,
+      modelUrl: MOCK_URL_INVALID_CHECKSUM,
+    };
+
+    await expect(client.fetchModel(mockTask)).rejects.toThrow();
+  });
+});

--- a/tests/fetchModel.test.ts
+++ b/tests/fetchModel.test.ts
@@ -4,7 +4,7 @@ import { EnvironmentSchema } from '../src/env-schema.js';
 import { ScribeMIClient } from '../src/index.js';
 import type { MIModel, MITask } from '../src/schema.js';
 
-configureEnv();
+configureEnv({ override: true });
 
 const env = EnvironmentSchema.parse(process.env);
 


### PR DESCRIPTION
Breaking change: needs to be merged alongside breaking change to the backend API

- New MD5 checksum parameter when creating tasks (breaking change, in line with backend)
- MD5 checksum validated when exporting models (non-breaking change)