### PR TITLE
feat!: upgrade to API v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,13 @@ The constructor expects an environment object:
 ```
 const EnvironmentSchema = object({
   API_URL: string(),
-  IDENTITY_POOL_ID: string(),
   USER_POOL_ID: string(),
   CLIENT_ID: string(),
   REGION: string(),
 });
 ```
 
-The `API_URL` is `"mi.scribelabs.ai/v1"`.
+The `API_URL` is `"mi.scribelabs.ai/v2"`.
 
 The `REGION` is `"eu-west-2"`.
 
@@ -34,9 +33,8 @@ Contact Scribe to obtain other details required for authentication.
 import { ScribeMIClient } from '@scribelabsai/mi';
 
 const client = new ScribeMIClient({
-  API_URL: 'mi.scribelabs.ai/v1',
+  API_URL: 'mi.scribelabs.ai/v2',
   REGION: 'eu-west-2',
-  IDENTITY_POOL_ID: 'Contact Scribe for authentication details',
   USER_POOL_ID: 'Contact Scribe for authentication details',
   CLIENT_ID: 'Contact Scribe for authentication details',
 });

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
   },
   "dependencies": {
     "@scribelabsai/auth": "^1.3.0",
-    "aws-sigv4-fetch": "^2.1.1",
     "crypto-js": "4.2.0",
     "zod": "^3.22.2"
   }

--- a/src/envSchema.ts
+++ b/src/envSchema.ts
@@ -2,7 +2,6 @@ import { object, string, infer as zinfer } from 'zod';
 
 export const EnvironmentSchema = object({
   API_URL: string(),
-  IDENTITY_POOL_ID: string(),
   USER_POOL_ID: string(),
   CLIENT_ID: string(),
   REGION: string(),

--- a/tests/mi.test.ts
+++ b/tests/mi.test.ts
@@ -72,7 +72,7 @@ describe('endpoints can be called', () => {
   it('submitTask', async () => {
     await expect(
       (async () => {
-        jobid = await client.submitTask(testFile, { filetype: 'pdf' });
+        jobid = await client.submitTask(testFile, { filetype: 'pdf', filename: 'Test file.pdf' });
       })()
     ).resolves.not.toThrow();
   });


### PR DESCRIPTION
Breaking changes compared to v1:
- Different API url (`/v1` instead of `/v2`)
- `filename` parameter to `POST` endpoint is now required
- Different authentication method (`Authorization` header using access token instead of sig-v4 signature; identity pool no longer required)